### PR TITLE
增加可以配置默认模型和深度研究限制

### DIFF
--- a/api/audit_limit.go
+++ b/api/audit_limit.go
@@ -40,6 +40,8 @@ func AuditLimit(r *ghttp.Request) {
 
 	model := reqJson.Get("model").String() // 模型名称
 	g.Log().Debug(ctx, "model", model)
+	system_hint := reqJson.Get("system_hints.0").String() // 系统提示
+	g.Log().Debug(ctx, "system_hint", system_hint)
 	prompt := reqJson.Get("messages.0.content.parts.0").String() // 输入内容
 	g.Log().Debug(ctx, "prompt", prompt)
 
@@ -74,6 +76,9 @@ func AuditLimit(r *ghttp.Request) {
 			r.Response.WriteJson(MsgMod400)
 			return
 		}
+	}
+	if system_hint != "research" {
+		model = "research"
 	}
 	limit, per, limiter, err := GetVisitorWithModel(ctx, token, model)
 	if err != nil {

--- a/api/audit_limit.go
+++ b/api/audit_limit.go
@@ -77,7 +77,7 @@ func AuditLimit(r *ghttp.Request) {
 			return
 		}
 	}
-	if system_hint != "research" {
+	if system_hint == "research" {
 		model = "research"
 	}
 	limit, per, limiter, err := GetVisitorWithModel(ctx, token, model)

--- a/api/limit.go
+++ b/api/limit.go
@@ -37,7 +37,10 @@ func GetVisitor(key string, limit int, per time.Duration) *rate.Limiter {
 
 func GetVisitorWithModel(ctx g.Ctx, token, model string) (limit int, per time.Duration, limiter *rate.Limiter, err error) {
 	model = gstr.ToUpper(model)
-	modelrate := g.Cfg().MustGetWithEnv(ctx, model, "40/3h").String()
+	modelrate := g.Cfg().MustGetWithEnv(ctx, model).String()
+	if modelrate == "" {
+		modelrate = g.Cfg().MustGetWithEnv(ctx, "DEFAULT").String()
+	}
 	modelratearr := strings.Split(modelrate, "/")
 	// g.Dump(modelratearr)
 	if len(modelratearr) != 2 {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,12 +1,18 @@
 PORT: 9612 
 OAIKEY: "" # OpenAI API key 用于内容审核
 MODERATION: "https://api.openai.com/v1/moderations"
+# 默认值
+DEFAULT: "20/3h"
 AUTO: "200/3h"
 TEXT-DAVINCI-002-RENDER-SHA: "200/3h"
 GPT-4O-MINI: "200/3h"
 GPT-4O: "60/3h"
 GPT-4: "20/3h"
 GPT-4O-CANMORE: "30/3h"
-O1-PREVIEW: "7/24h"
-O1-MINI: "50/24h"
+O1-PRO: "7/24h"
+O3-PRO: "7/24h"
+O3: "7/24h"
+O4-MINI: "50/24h"
+O4-MINI-HIGH: "50/24h"
+RESEARCH: "2/24h"
 TEST: "1/1h"


### PR DESCRIPTION
1. 增加 DEFAULT 参数，可以给没有设置的模型一个默认次数，优先级为 model > DEFAULT > "40/3h"
DEFAULT: "40/3h"

2. 增加 RESEARCH 参数，限制深入研究的次数
RESEARCH: "2/24h"

3. 更新 config.yaml 到目前的模型